### PR TITLE
Optimize for smaller texture

### DIFF
--- a/custom-types/index.d.ts
+++ b/custom-types/index.d.ts
@@ -1,18 +1,4 @@
-// import type chart from "../src/d3/pizza";
 declare type Chart = ReturnType<typeof import("../src/d3/pizza").pizzaChart>
-
-// {
-//     (selection: d3.Selection<HTMLDivElement, any, any, any>): void
-//     data(value:any[]):Chart
-//     sliceKey(value:string):Chart
-//     sliceSet(value:string[]):Chart
-//     sliceColors(value: {[slice:string]:string[]}):Chart
-//     ringKey(value:string):Chart
-//     ringSet(value:string[]):Chart
-//     margin(value:Margin):Chart,
-//     canvasWidth(value:number):Chart
-//     canvasHeight(value:number):Chart
-// } 
 
 declare type Arc = {
     path: string;
@@ -127,13 +113,21 @@ declare interface QueueInterface<T> {
 declare type ChangeDuration = Task<'duration', number>
 declare type UpdateSections = Task<'sections', Section[]>
 declare type QueueTask = ChangeDuration | UpdateSections
+declare type Subsection = {
+    id: string,
+    startAngle:number,
+    endAngle:number,
+    innerRadius:number,
+    outerRadius:number,
+}
 declare type Section = {
     id: string,
     fill: string,
     startAngle:number,
     endAngle:number,
     innerRadius:number,
-    outerRadius:number
+    outerRadius:number,
+    subsections:Subsection[]
 }
 
 declare type ParameterType = 'ring' | 'slice' | 'color'

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "source": "src/index.html",
   "scripts": {
     "start": "parcel --no-cache",
-    "build": "parcel --no-cache build",
+    "build": "parcel build --no-cache",
     "browserify": "browserify src/DOMImplementation.js --s xmldom > src/DOMImplementation_bundle.js",
-    "predeploy": "rm -rf dist && parcel --no-cache build src/index.html --public-url https://averyburke.github.io/pie/",
+    "predeploy": "rm -rf dist && yarn build src/index.html --public-url https://averyburke.github.io/pie/",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {

--- a/src/static/lloydClass.ts
+++ b/src/static/lloydClass.ts
@@ -538,11 +538,14 @@ export default class VornoiMesh {
   }
 
   render() {
-      // const debugColors:number[] = []
+      const debugColors:number[] = []
       // const numberOfArcs = new Set(this.offsetArcIds)
       // for (let i = 0; i < numberOfArcs.size + 1; i++) {
       //     debugColors.push(Math.random(), Math.random(), Math.random())
       // }
+    //   for (let i = 0; i < this.offsets.length; i += 2) {
+    //     debugColors.push(Math.random(), Math.random(), Math.random())
+    // }
       // console.log('rendering with offsets ', this.offsets)
       for (let i = 0; i < this.cycles; i++) {
         this.gl.flush()

--- a/src/static/partitionNumber.ts
+++ b/src/static/partitionNumber.ts
@@ -1,0 +1,19 @@
+const partitionNumber = (num = 1, parts = 1) => {
+  let n = Math.floor(num / parts);
+  const arr = [];
+
+  for (let i = 0; i < parts; i++) {
+    arr.push(n);
+  }
+  if (arr.reduce((a, b) => a + b, 0) === num) {
+    return arr;
+  }
+  for (let i = 0; i < parts; i++) {
+    arr[i]++;
+    if (arr.reduce((a, b) => a + b, 0) === num) {
+      return arr;
+    }
+  }
+};
+
+export default partitionNumber

--- a/src/workers/backgroundWorker.ts
+++ b/src/workers/backgroundWorker.ts
@@ -90,7 +90,7 @@ class worker {
                             const partitions = partitionNumber(arcCount[id], Math.ceil(arcCount[id] / 300))
                             if (partitions){
                                 for (let i = 0; i < partitions.length; i++) {
-                                    const subarcId = `_${slice}_${ring}_subarc_${i}`
+                                    const subarcId = id + `_subarc_${i}`
                                     arcCount[subarcId] = partitions[i];
                                     this.idSet.insert(subarcId)
                                     const theta = endAngle - startAngle
@@ -99,11 +99,19 @@ class worker {
                                     subsections.push({startAngle:sa,endAngle:ea,innerRadius,outerRadius,id:subarcId})
                                 }
                             }
-                        } else {
+                        } else  if (state === 'add') {
+                            this.idSet.insert(id)
                             subsections.push({id,innerRadius,outerRadius,endAngle,startAngle})
                         }
-                        if (state === 'add') this.idSet.insert(id)
-                        if (state === 'remove') this.idSet.remove(id)
+                        if (state === 'remove') {
+                            this.idSet.remove(id)
+                            if (arcCount[id] > 300){
+                                for (let i = 0; i < Math.ceil(arcCount[id] / 300); i++) {
+                                    const subid = id + `_subarc_${i}`
+                                    this.idSet.remove(subid)
+                                }
+                            }
+                        }
                         const slicePallet = sliceColors[slice]!
                         const fill = slicePallet[j % slicePallet.length]!
                         const arc = { id, innerRadius, outerRadius, startAngle, endAngle, fill, subsections }
@@ -113,7 +121,7 @@ class worker {
                 }, [])
                 acc = [...acc, ...sections]
             }
-            console.log("arcs ", acc)
+            console.log("id set ", this.idSet)
             return acc
         }, [])
 
@@ -130,7 +138,7 @@ class worker {
             const { startAngle, endAngle } = sliceAngles[slice]!
             return ringSet.map((ring, j) => {
                 const { innerRadius, outerRadius } = ringHeights[ring]!
-                const id = `_${slice}_${ring}`
+                const id = `_${slice}_${ring}_init`
                 this.idSet.insert(id)
                 const slicePallet = sliceColors[slice]!
                 const fill = slicePallet[j % slicePallet.length]!
@@ -259,7 +267,6 @@ class worker {
                     const { startAngle, endAngle, innerRadius, outerRadius, id } = sub
                     // const centroid = arc().centroid({startAngle, endAngle, innerRadius, outerRadius})
                     // const centroid = [Math.round(x), Math.round(y)]
-                    // console.log({arcCount, id:d.id})
                     for (let i = 0; i < arcCount[id]; ++i) {
                             const randomClampedR = Math.random() * (outerRadius - innerRadius) + innerRadius,
                                 randomClampedTheta = (Math.random() * (endAngle - startAngle) + startAngle) - Math.PI / 2,

--- a/src/workers/shapeWorker.ts
+++ b/src/workers/shapeWorker.ts
@@ -53,7 +53,6 @@ self.addEventListener("message", (eve) => {
   } = eve.data;
   switch (type) {
     case "init": {
-      console.log({colorScale})
       backgroundRadius = radius
       ctx = canvas.getContext("2d")!;
       textureWidth = textureW;
@@ -101,7 +100,7 @@ self.addEventListener("message", (eve) => {
     break;
     case "update_ids":{
       if (ids){
-        console.log({ids})
+        // console.log({ids})
         inputData = ids;
       }
     }
@@ -121,7 +120,7 @@ self.addEventListener("message", (eve) => {
           data[i].colorValue = colorValues[i];
         }
       }
-      console.log("colors updated: ", data)
+      // console.log("colors updated: ", data)
     }
     break;
     case "update_color_scale":{
@@ -134,7 +133,7 @@ self.addEventListener("message", (eve) => {
 });
 
 function handlePositions({payload, keepOpen}:{payload:Float32Array, keepOpen:boolean}) {
-  console.log({keepOpen, previouslyPayloadLength})
+  // console.log({keepOpen, previouslyPayloadLength})
   for (let i = 0; i < payload.length; i += 2) {
     /* 
      * ids are sorted and positions are sorted, before they are sent to the shape worker. This has the effect of presisting ids
@@ -186,6 +185,6 @@ function init(canvas: OffscreenCanvas) {
     // if (!floatExtention){
     //   console.error("compressed floating point texture not avaiable on this machine")
     // }
-    vornoi = new VornoiMesh(gl, textureWidth, textureHeight, 200, handlePositions);
+    vornoi = new VornoiMesh(gl, textureWidth, textureHeight, 100, handlePositions);
   }
 }


### PR DESCRIPTION
after some testing I've found that the current texture size (312 X 312) looses positions when there are more than 325 Vornoi cells. This branch adds an optimization, where arcs with more than 300 cells are divided up more or less evenly into subarcs. The subarcs are tagged, triangulated and sent to the Vornoi mesh generator, where they are handled in groups--the subarcs are not sent to the d3 background renderer