### PR TITLE
adds rotation for slice set changes

### DIFF
--- a/custom-types/index.d.ts
+++ b/custom-types/index.d.ts
@@ -8,7 +8,7 @@ declare type User = {
     chirality: 'left handed' | 'right handed'
     subscriptionTier: 'free' | 'basic' | 'business',
     buildingNumber: 'bld_1' | 'bld_2' | 'bld_3' | 'bld_4' | 'bld_5'
-  };
+};
 
 declare type Arc = {
     path: string;
@@ -28,7 +28,7 @@ declare type Arc = {
     theta?: number;
 }
 
-type Datum = {id:string, x:number, y:number, colorValue:string, shapeValue:string}
+type Datum = {id:string, x:number, y:number, colorValue:string, shapeValue:string, sliceValue:string, ringValue:string}
 
 declare type Margin = {
     top: number,

--- a/src/static/rotateCoordinates.ts
+++ b/src/static/rotateCoordinates.ts
@@ -1,0 +1,9 @@
+const rotateCoordinates = (oldX:number,oldY:number,theta:number):[number,number] => {
+
+    const newX = (oldX * Math.cos(theta)) + (oldY * Math.sin(theta))
+    const newY = (-1 * oldX * Math.sin(theta)) + (oldY * Math.cos(theta))
+
+    return [newX, newY]
+}
+
+export default rotateCoordinates

--- a/src/workers/backgroundWorker.ts
+++ b/src/workers/backgroundWorker.ts
@@ -121,7 +121,6 @@ class worker {
                 }, [])
                 acc = [...acc, ...sections]
             }
-            console.log("id set ", this.idSet)
             return acc
         }, [])
 
@@ -176,10 +175,11 @@ class worker {
             this.background.enqueue(startSlices)
         }
         this.sliceAngles = sliceAngles
-        this.getPathPoints()
+        // this.getPathPoints()
         const endSlices: QueueTask = { type: "sections", input: this.generateArcs() }
         this.background.enqueue(endSlices)
         this.background.dequeue()
+        // this.getPathPoints()
     }
 
     removeSlices() {
@@ -231,6 +231,7 @@ class worker {
     }
 
     getPathPoints() {
+        console.log('getting points')
         const { generator} = this
         const sectionCoords: [number, number, number][] = []
         const sectionVerts: number[] = []
@@ -343,5 +344,8 @@ self.addEventListener('message', msg => {
     }
     if (type === 'remove_slices') {
         brw.removeSlices()
+    }
+    if (type === 'get_points'){
+        brw.getPathPoints()
     }
 })


### PR DESCRIPTION
The Voronoi mesh is not recalculated when slices are shuffled. Instead points are rotated to their new position. This introduces a bug with filtering. To fix later