### PR TITLE
Get positions by

### DIFF
--- a/custom-types/index.d.ts
+++ b/custom-types/index.d.ts
@@ -269,7 +269,7 @@ declare type BackgroundWorkerUpdateSliceAngles = BackgroundWorkerMsg<
 	{ sliceAngles: { [slice: string]: { startAngle: number; endAngle: number } } }
 >;
 declare type BackgroundWorkerRemoveSlices = BackgroundWorkerMsg<"remove_slices", {}>;
-declare type BackgroundWorkerGetPoints = BackgroundWorkerMsg<"get_points", {}>;
+declare type BackgroundWorkerGetPoints = BackgroundWorkerMsg<"get_points", {arcIds:Set<string>}>;
 
 declare type BackgroundWorkerAction =
 	| BackgroundWorkerInit

--- a/src/d3/pizza.ts
+++ b/src/d3/pizza.ts
@@ -218,6 +218,10 @@ function pizzaChart(): typeof chart {
 					//if slice angles have changed then calling updateRingHeights will update the background as well
 					updateRingHeights();
 				}
+				backgroundWorker.postMessage({
+					type:"get_points",
+					payload:{}
+				})
 			};
 
 			updateSliceKey = function () {
@@ -284,6 +288,10 @@ function pizzaChart(): typeof chart {
 				backgroundWorker.postMessage({ type: "update_arc_count", payload: { arcCount } });
 				ringCount = Object.fromEntries(ringSet.map((ring) => [ring, data.filter((d) => ringValue(d) === ring).length]));
 				updateRingHeights();
+				backgroundWorker.postMessage({
+					type:"get_points",
+					payload:{}
+				})
 			};
 
 			updateColorKey = function () {
@@ -372,13 +380,7 @@ function pizzaChart(): typeof chart {
 				return 0;
 			}
 			//boot
-			// updateSliceKey()
-			updateSliceSet();
-			// updateRingKey()
-			// updateRingSet()
-			// updateColorKey()
-			// updateColorScale()
-			// updateData()
+
 		});
 	}
 

--- a/src/workers/backgroundWorker.ts
+++ b/src/workers/backgroundWorker.ts
@@ -217,7 +217,7 @@ class worker {
 		this.ringHeights = ringHeights;
 		this.background.enqueue({ type: "sections", input: this.generateArcs() });
 		this.background.dequeue();
-		this.getPathPoints();
+		// this.getPathPoints();
 	}
 
 	removeRings() {
@@ -234,8 +234,13 @@ class worker {
 		this.ringSet = [];
 	}
 
+	/**
+	 * sectionVerts = triangulation of the arcs.
+	 * sectionCoords = [random x coordinate, random y coordinate, integer id of the containing arc][]
+	 * 
+	 * @postMessage {sectionVerts:number[], sectionCoords:[number, number, number][] }
+	 */
 	getPathPoints() {
-		console.log("getting points");
 		const { generator } = this;
 		const sectionCoords: [number, number, number][] = [];
 		const sectionVerts: number[] = [];


### PR DESCRIPTION
moves the call to get arc triangulation and seed points from the background worker to explicit command by the calling function. The command takes the set of arcids whose coordinates and seeds should be returned. this sets up for the next refactor: only recalculate positions for arcs that have changed